### PR TITLE
Veni Vedi Vici

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # weatherspeaker
-[![version](https://img.shields.io/badge/version-v1.0.1-red.svg)](https://github.com/marrakchino/weatherspeaker/releases)
+[![version](https://img.shields.io/badge/version-v1.1.0-red.svg)](https://github.com/marrakchino/weatherspeaker/releases)
 [![license](http://img.shields.io/badge/license-mit-blue.svg)](https://opensource.org/licenses/MIT)
 
 **weatherspeaker** | a command-line weather forecast speaker. It allows the user to hear the weather forecast of a particular location for a particular date
@@ -23,21 +23,41 @@ The API key might take several minutes before it becomes valid. To test it, chec
 
 # Configuration
 
-## Via init
+## Configuration file
+
+You can directly store your settings in a dedicated file: `config/.weatherspeaker.conf` (or set the variable `CONFIG_FILE` to another directory of your choice) in the following format:
+
+```sh
+key:<YOUR_API_KEY>
+id:<YOUR_DEFAULT_CITY_ID>
+```
+
+The order of the lines is indifferent, but make sure there are no trailing spaces or useless characters.
+
+### Resetting the variables
+
+You can overwrite these environment variables (if you happen to change the city or to use a new API key) by invoking `init`:
 
 ```sh
 $ weatherspeaker init
+API Key already exists in /home/marrakchino/github/weatherspeaker/config/.weatherspeaker.conf, overwrite it? [y]es, [n]o y
+New API key: 123456789
+[API KEY] Overwrote API key in /home/marrakchino/github/weatherspeaker/config/.weatherspeaker.conf
+Default city ID already exists in /home/marrakchino/github/weatherspeaker/config/.weatherspeaker.conf, overwrite it? [y]es, [n]o y
+New city ID: 1234566778
+[City ID] Overwrote city ID in /home/marrakchino/github/weatherspeaker/config/.weatherspeaker.conf
 ```
 
 ## Setting environment
 
-- You may want export these environment variables (adding them to your ~/.bashrc file for example):
+Otherwise, you may (will) have to export these environment variables (adding them to your ~/.bashrc file for example):
 
 `export OPENWEATHERMAP_APIKEY=<YOUR_API_KEY>`
 
 `export WTSPEAK_DEFAULT_CITY_ID=<DEFAULT_CITY_ID>` 
 
 - One other possibility (recommended) is to create two files: `config/.openweathermap_apikey` and `config/.default_city_id` with the following contents:
+
 ```sh
 $ cat config/.openweathermap_apikey
 <YOUR_API_KEY>
@@ -49,14 +69,16 @@ $ cat config/.default_city_id
 # Usage 
 
 ```sh
-$ weatherspeaker --help 
-Weatherspeaker - Command line weather forecast speaker
+$ weatherspeaker --help
+weatherspeaker - Command line weather forecast speaker
 Options:
-    [--trace | --verbose]     Activate tracing.
-    [--help | -h]             Show this help and exit.
-    [--version | -v]          Display the version of the program and exit.
-    [init]                    Initialize and configure your personal parameters (API Key and city ID).
-Github repository: 	      http://gihthub.com/marrakchino/weatherspeaker
+    [--config-file | -c] <path>        Use a custom configuration file located in <path>.
+    [--trace | --verbose]              Activate tracing.
+    [--help | -h]                      Show this help and exit.
+    [--version | -v]                   Display the version of the program and exit.
+    [init]                             Initialize and configure your personal parameters (API Key and city ID).
+
+    Github repository: 		     http://gihthub.com/marrakchino/weatherspeaker
 ```
 
 # Cron
@@ -78,6 +100,8 @@ A non-exhaustive list of suggested unsolved bugs/improvement ideas is given here
 * Use the functions `get_coordinates_from_ip` and `get_city_country_from_ip` to allow the user to use the program without explicitly specifying a city. See for example how you can extract the city ID number by knowing its name from: http://www.openweathermap.org/help/city_list.txt as the API is not performing well when only providing a city name.
 
 * Add a `-d` option to specify the 'day delay' of the forecast, e.g. invoking `weatherspeaker -d 3` returns the weather forecast of 3 days later.
+
+* Add a `-c` option to use a custom configuration file (in a different location) instead of config/.weatherspeaker.conf. See `display_usage`.
 
 * Improve weather forecast script.
 

--- a/README.md
+++ b/README.md
@@ -56,16 +56,6 @@ Otherwise, you may (will) have to export these environment variables (adding the
 
 `export WTSPEAK_DEFAULT_CITY_ID=<DEFAULT_CITY_ID>` 
 
-- One other possibility (recommended) is to create two files: `config/.openweathermap_apikey` and `config/.default_city_id` with the following contents:
-
-```sh
-$ cat config/.openweathermap_apikey
-<YOUR_API_KEY>
-
-$ cat config/.default_city_id
-<YOUR_CITY_ID>
-```
-
 # Usage 
 
 ```sh

--- a/weatherspeaker
+++ b/weatherspeaker
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
+set -e
+VERSION="1.1.0"
 
 HERE=$(cd "$(dirname "$0")" && pwd)
+CONFIG_FILE="$HERE/config/.weatherspeaker.conf"
 
-if [ -f "$HERE/config/.openweathermap_apikey" ]; then
-	api_key=$(sed -n '1p' < "$HERE/config/.openweathermap_apikey")
+if [ -f "$CONFIG_FILE" ]; then
+	api_key=$(grep "key" "$CONFIG_FILE"| sed -e 's/.*key://g')
 else
 	api_key="$OPENWEATHERMAP_APIKEY"
 fi
 
-if test -f "$HERE/config/.default_city_id"; then
-	city_id=$(sed -n '1p' < "$HERE/config/.default_city_id")
+if test -f "$CONFIG_FILE"; then
+	city_id=$(grep "id" "$CONFIG_FILE"| sed -e 's/.*id://g')
 else
 	city_id="$WTSPEAK_DEFAULT_CITY_ID"
 fi
@@ -17,13 +20,13 @@ fi
 UNITS=metric # Default:Kelvin, Metric:Celsius, Imperial:Fahrenheit
 WEATHER_URL="http://api.openweathermap.org/data/2.5/forecast?id=$city_id&APPID=$api_key&units=$UNITS"
 
-ESPEAK=espeak
-espeak_data_path="$($ESPEAK --version| sed 's/.*Data at: //g')"
+ESPEAK_BIN=espeak
+espeak_data_path="$($ESPEAK_BIN --version| sed 's/.*Data at: //g')"
 if [ ! -f "$espeak_data_path/voices/female_custom_voice" ]; then
 	# copy the custom voice file if it's not already in the expected directory
 	cp "$HERE/female_custom_voice" "$espeak_data_path/voices/female_custom_voice"
 fi
-ESPEAK="$ESPEAK -v female_custom_voice"
+ESPEAK_BIN="$ESPEAK_BIN -v female_custom_voice"
 
 current_hour_of_the_day=$(date +%H)
 
@@ -41,41 +44,76 @@ else
 fi
 
 display_usage(){
-	echo "Weatherspeaker - Command line weather forecast speaker"
+	echo "weatherspeaker - Command line weather forecast speaker"
 	echo "Options:"
-	echo "    [--trace | --verbose]     Activate tracing."
-	echo "    [--help | -h]             Show this help and exit."
-	echo "    [--version | -v]          Display the version of the program and exit."
-	echo "    [init]                    Initialize and configure your personal parameters (API Key and city ID)."
-	echo "Github repository: 	    http://gihthub.com/marrakchino/weatherspeaker"
+	# not yet supported
+	echo "    [--config-file | -c] <path>        Use a custom configuration file located in <path>." 
+	echo "    [--trace | --verbose]              Activate tracing."
+	echo "    [--help | -h]                      Show this help and exit."
+	echo "    [--version | -v]                   Display the version of the program and exit."
+	echo "    [init]                             Initialize and configure your personal parameters (API Key and city ID)."
+	echo ""
+	echo "    Github repository: 		     http://gihthub.com/marrakchino/weatherspeaker"
 	exit 0
 }
 
+# $1: item to replace (key, id)
+# $2: new value
+replace_conf(){
+	sed -i "s/$1.*$/$1:$2/" "$CONFIG_FILE"
+}
+
 display_version(){
-	echo "weatherspeaker - Version 1.0"
+	echo "weatherspeaker - Version $VERSION"
 	exit 0
 }
 
 init(){
-	echo "$api_key" > "$HERE/config/.openweathermap_apikey"
-	case "$?" in
-		0)
-			echo "[API Key] Done";;
-		*)
-			echo "[API Key] Error when writing"
-			return 1
-			;;
-	esac
+	if grep -q "key" "$CONFIG_FILE"; then
+		read -p "API Key already exists in $CONFIG_FILE, overwrite it? [y]es, [n]o " action
+		case "$action" in
+			y)
+				read -p "New API key: " new_api_key
+				replace_conf "key" "$new_api_key"
+				echo "[API KEY] Overwrote API key in $CONFIG_FILE"
+				;;
+			*)
+				;;
+		esac
+	else	
+		echo "key:$api_key" >> "$CONFIG_FILE"
+		case "$?" in
+			0)
+				echo "[API Key] Done";;
+			*)
+				echo "[API Key] Error when writing"
+				return 1
+				;;
+		esac
+	fi
 
-	echo "$city_id" > "$HERE/config/.default_city_id"
-	case "$?" in
-		0)
-			echo "[City ID] Done";;
-		*)
-			echo "[City ID] Error when writing"
-			return 1
-			;;
-	esac
+	if grep -q "id" "$CONFIG_FILE"; then
+		read -p "Default city ID already exists in $CONFIG_FILE, overwrite it? [y]es, [n]o " action
+		case "$action" in
+			y)
+				read -p "New city ID: " new_city_id
+				replace_conf "id" "$new_city_id"
+				echo "[City ID] Overwrote city ID in $CONFIG_FILE"
+				;;
+			*)
+				;;
+		esac
+	else
+		echo "id:$city_id" >> "$CONFIG_FILE"
+		case "$?" in
+			0)
+				echo "[City ID] Done";;
+			*)
+				echo "[City ID] Error when writing"
+				return 1
+				;;
+		esac
+	fi
 }
 
 # Command line parsing
@@ -95,8 +133,8 @@ while (( "$#" )); do
 			;;
 			
 		init)
-			if [ -f "$HERE/config/.openweathermap_apikey" ]; then
-				api_key=$(sed -n '1p' < "$HERE/config/.openweathermap_apikey")
+			if [ -f "$CONFIG_FILE" ]; then
+				api_key=$(grep "key" "$CONFIG_FILE"| sed -e 's/.*key://g')
 			else
 				api_key=$OPENWEATHERMAP_APIKEY
 			fi
@@ -105,8 +143,8 @@ while (( "$#" )); do
 				read -e -p "Enter your API key: " api_key
 			fi
 
-			if [ -f "$HERE/config/.default_city_id" ]; then
-				city_id=$(sed -n '1p' < "$HERE/config/.default_city_id")
+			if [ -f "$CONFIG_FILE" ]; then
+				city_id=$(grep "id" "$CONFIG_FILE"| sed -e 's/.*id://g')
 			else
 				city_id="$WTSPEAK_DEFAULT_CITY_ID"
 			fi
@@ -118,20 +156,17 @@ while (( "$#" )); do
 			exit $?
 			;;
 
+# 		-c| --config-file)
+# 			CONFIG_FILE="$2"
+# 			shift 2 || break
+# 			;;
+
 		*)
 			shift 1 || break
 			;;
 			
 	esac
 done
-
-# Exit if the environment variables are not defined
-# TODO: Prompt the user for the API key and default city id/city name if the 
-# environment variables are not defined
-# [ -z "$OPENWEATHERMAP_APIKEY" ] && echo "API Key not defined" && exit 1; 
-# [ -z "$api_key" ] && echo "API Key not defined" && exit 1; 
-# # read -e -p 'Enter your OpenWeatherMap API key: ' "$OPENWEATHERMAP_APIKEY"
-# [ -z "$WTSPEAK_DEFAULT_CITY_ID" ] && echo "Default city ID not defined" && exit 1;
 
 weather_forecast_script=""
 if [ "$afternoon" -gt 0 ]; then
@@ -169,6 +204,8 @@ adjectify_description(){
 	
 	elif [ "$weather_main_description" == "Extreme" ]; then
 		weather_forecast_script="$weather_forecast_script extreme."
+	else
+		weather_forecast_script="$weather_forecast_script normal."
 	fi
 }
 
@@ -201,7 +238,7 @@ curl_weather(){
 	jq ".list[((11 - $day_offset))]| .weather[] .main")
 	
 	weather_full_description=$(curl -s "$WEATHER_URL"|
-	jq ".list[$((11 - $day_offset))]| .weather[] .description")
+	jq ".list[((11 - $day_offset))]| .weather[] .description")
 	
 	weather_code=$(curl -s "$WEATHER_URL"| jq '.cod')
 
@@ -210,7 +247,6 @@ curl_weather(){
 
 	weather_afternoon_temp=$(curl -s "$WEATHER_URL"|
 	jq ".list[((11 - $day_offset + 2))]| .main.temp")
-
 }
 
 curl_weather 1
@@ -219,5 +255,5 @@ temperaturify_description
 
 # Don't speak unless the information has been correctly fetched 
 if [[ -n "$weather_morning_temp" && -n "$weather_afternoon_temp" ]]; then
-	$ESPEAK "$weather_forecast_script" &
+	$ESPEAK_BIN "$weather_forecast_script" &
 fi


### PR DESCRIPTION
Implemented the new unified configuration format read/write and
overwrite.
There's now only one configuration file needed for both environment
variables: key and id. The user may also overwrite these parameters by
invoking weatherspeaker init and chosing the overwrite options.
Next: add the -c (and -d too) argument to use a custom config file.